### PR TITLE
add units to offset/duration fields

### DIFF
--- a/src/EDF.jl
+++ b/src/EDF.jl
@@ -57,14 +57,14 @@ Type representing a time-stamp annotations list (TAL).
 
 # Fields
 
-* `offset` (`Float64`): Offset from the recording start time (specified in the header)
+* `offset_in_seconds` (`Float64`): Offset in seconds from the recording start time (specified in the header)
   at which the event in this TAL starts
-* `duration` (`Float64` or `Nothing`): Duration of the event, if specified
+* `duration_in_seconds` (`Float64` or `Nothing`): Duration of the event in seconds, if specified
 * `event` (`Vector{String}`): List of events for this TAL
 """
 struct AnnotationsList
-    offset::Float64
-    duration::Union{Float64,Nothing}
+    offset_in_seconds::Float64
+    duration_in_seconds::Union{Float64,Nothing}
     event::Vector{String}
 end
 
@@ -75,8 +75,8 @@ Type containing all annotations applied to a particular data record.
 
 # Fields
 
-* `offset` (`Float64`): Offset from the recording start time (specified in the header)
-  at which the current data record starts
+* `offset_in_seconds` (`Float64`): Offset in seconds from the recording start
+  time (specified in the header) at which the current data record starts
 * `event` (`Vector{String}` or `Nothing`): The event that marks the start of the data
   record, if applicable
 * `annotations` (`Vector{EDF.AnnotationsList}`): The time-stamped annotations lists (TALs)
@@ -84,13 +84,15 @@ Type containing all annotations applied to a particular data record.
 * `n_bytes` (`Int`): The number of raw bytes per data record in the "EDF Annotation" signal
 """
 mutable struct RecordAnnotation
-    offset::Float64
+    offset_in_seconds::Float64
     event::Union{Vector{String},Nothing}
     annotations::Vector{AnnotationsList}
     n_bytes::Int
 
     RecordAnnotation() = new()
-    RecordAnnotation(offset, event, annotations, n_bytes) = new(offset, event, annotations, n_bytes)
+    function RecordAnnotation(offset_in_seconds, event, annotations, n_bytes)
+        return new(offset_in_seconds, event, annotations, n_bytes)
+    end
 end
 
 """
@@ -105,7 +107,7 @@ Type representing the header record for an EDF file.
 * `recording` (`String` or `EDF.RecordingID`): Local recording identification
 * `start` (`DateTime`): Date and time the recording started
 * `n_records` (`Int`): Number of data records
-* `duration` (`Float64`): Duration of a data record in seconds
+* `duration_in_seconds` (`Float64`): Duration of a data record in seconds
 * `n_signals` (`Int`): Number of signals in a data record
 * `nb_header` (`Int`): Total number of raw bytes in the header record
 """
@@ -116,7 +118,7 @@ struct Header
     continuous::Bool
     start::DateTime
     n_records::Int
-    duration::Float64
+    duration_in_seconds::Float64
     n_signals::Int
     nb_header::Int
 end

--- a/src/read.jl
+++ b/src/read.jl
@@ -128,7 +128,7 @@ function read_header(io::IO)
         n_signals -= 1
     end
 
-    # @assert position(io) == nb_header
+    @assert position(io) == nb_header
 
     h = Header(version, patient_id, recording_id, continuous, start, n_records,
                duration, n_signals, nb_header)

--- a/src/read.jl
+++ b/src/read.jl
@@ -128,7 +128,7 @@ function read_header(io::IO)
         n_signals -= 1
     end
 
-    @assert position(io) == nb_header
+    # @assert position(io) == nb_header
 
     h = Header(version, patient_id, recording_id, continuous, start, n_records,
                duration, n_signals, nb_header)
@@ -156,7 +156,7 @@ function read_data!(io::IO, signals::Vector{Signal}, header::Header, anno_idx::I
                 while !eof(record) && Base.peek(record) != 0x0
                     toplevel, offset, duration, events = read_tal(record)
                     if toplevel
-                        anno.offset = offset
+                        anno.offset_in_seconds = offset
                         anno.event = events
                         anno.n_bytes = n_bytes
                     else

--- a/src/write.jl
+++ b/src/write.jl
@@ -20,9 +20,9 @@ _write(io::IO, ::Missing) = Base.write(io, "X")
 _write(io::IO, x::AbstractFloat) = Base.write(io, string(isinteger(x) ? trunc(Int, x) : x))
 
 function _write(io::IO, tal::AnnotationsList)
-    nb = _write(io, tal.offset >= 0 ? '+' : '-') + _write(io, tal.offset)
-    if tal.duration !== nothing
-        nb += Base.write(io, 0x15) + _write(io, tal.duration)
+    nb = _write(io, tal.offset_in_seconds >= 0 ? '+' : '-') + _write(io, tal.offset_in_seconds)
+    if tal.duration_in_seconds !== nothing
+        nb += Base.write(io, 0x15) + _write(io, tal.duration_in_seconds)
     end
     nb += Base.write(io, 0x14)
     mark = position(io)
@@ -33,8 +33,8 @@ function _write(io::IO, tal::AnnotationsList)
 end
 
 function _write(io::IO, anno::RecordAnnotation)
-    nb = _write(io, anno.offset >= 0 ? '+' : '-') +
-         _write(io, anno.offset) +
+    nb = _write(io, anno.offset_in_seconds >= 0 ? '+' : '-') +
+         _write(io, anno.offset_in_seconds) +
          Base.write(io, 0x14, 0x14)
     mark = position(io)
     join(io, anno.event, '\x14')
@@ -69,7 +69,7 @@ function write_header(io::IO, file::File)
         write_padded(io, h.nb_header, 8) +
         write_padded(io, h.continuous ? "EDF+C" : "EDF+D", 44) +
         write_padded(io, h.n_records, 8) +
-        write_padded(io, h.duration, 8) +
+        write_padded(io, h.duration_in_seconds, 8) +
         write_padded(io, h.n_signals + has_anno, 4)
     pads = [16, 80, 8, 8, 8, 8, 8, 80, 8]
     av = Any["EDF Annotations", "", "", -1, 1, -32768, 32767, ""]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,7 +45,7 @@ const DATADIR = joinpath(@__DIR__, "data")
     @test edf.header.continuous
     @test edf.header.start == DateTime(2014, 4, 29, 22, 19, 44)
     @test edf.header.n_records == 6
-    @test edf.header.duration == 1.0
+    @test edf.header.duration_in_seconds == 1.0
     @test edf.header.n_signals == 139
     @test edf.signals isa Vector{Signal}
     @test length(edf.signals) == edf.header.n_signals
@@ -89,7 +89,7 @@ const DATADIR = joinpath(@__DIR__, "data")
     @test uneven.header.continuous
     @test uneven.header.start == DateTime(2000, 7, 13, 12, 5, 48)
     @test uneven.header.n_records == 11
-    @test uneven.header.duration == 10.0
+    @test uneven.header.duration_in_seconds == 10.0
     @test uneven.header.n_signals == 2
     @test uneven.signals[1].n_samples != uneven.signals[2].n_samples
     @test uneven.annotations === nothing


### PR DESCRIPTION
For now, this PR is a simple code readability improvement to make up for the fact that these fields aren't typed `Second`. 

On the one hand, it makes sense for these quantities to be typed `Float64`, as EDF+ serializes some of these quantities as numeric strings in floating-point notation.

~~On the other hand, it looks like EDF.jl [silently truncates non-integers to integers when writing](https://github.com/beacon-biosignals/EDF.jl/blob/master/src/write.jl#L20). Assuming my reading of that is correct (it might not be!), wouldn't it be better to just type these fields as `Second` for now, so that users trying to encode non-integer durations will get a nice type error instead of unknowingly writing incorrect data? Then, once EDF.jl actually supports fractional durations/offsets, that front-end restriction can be lifted. If my reading is correct I can make that change to type the fields as `Second`, just let me know.~~ EDIT: I am dummy