### PR TITLE
Avoid bounds errors while accessing signal data for writing

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -95,7 +95,8 @@ function write_data(io::IO, file::File)
         for signal in file.signals
             n = signal.n_samples
             s = (i - 1) * n
-            b += Base.write(io, view(signal.samples, s+1:s+n))
+            stop = min(s + n, length(signal.samples))
+            b += Base.write(io, view(signal.samples, s+1:stop))
         end
         if file.annotations !== nothing
             b += _write(io, file.annotations[i])


### PR DESCRIPTION
The computed stopping point for writing signal chunks may exceed the length of the actual data, resulting in a bounds error. To fix that, we can just take the minimum of the computed stop and the actual length.

Should have a test. Came across this case in the wild.