### PR TITLE
Handle non-integer physical/digital extrema values

### DIFF
--- a/src/EDF.jl
+++ b/src/EDF.jl
@@ -133,10 +133,10 @@ Type representing a single signal extracted from an EDF file.
 * `label` (`String`): The name of the signal, e.g. `F3-M2`
 * `transducer` (`String`): Transducer type
 * `physical_units` (`String`): Units of measure for the signal, e.g. `uV`
-* `physical_min` (`Int16`): The physical minimum value of the signal
-* `physical_max` (`Int16`): The physical maximum value of the signal
-* `digital_min` (`Int16`): The minimum value of the signal that could occur in a data record
-* `digital_max` (`Int16`): The maximum value of the signal that could occur in a data record
+* `physical_min` (`Float32`): The physical minimum value of the signal
+* `physical_max` (`Float32`): The physical maximum value of the signal
+* `digital_min` (`Float32`): The minimum value of the signal that could occur in a data record
+* `digital_max` (`Float32`): The maximum value of the signal that could occur in a data record
 * `prefilter` (`String`): Description of any prefiltering done to the signal
 * `n_samples` (`Int16`): The number of samples in a data record (NOT overall)
 * `samples` (`Vector{Int16}`): The sample values of the signal
@@ -145,10 +145,10 @@ mutable struct Signal
     label::String
     transducer::String
     physical_units::String
-    physical_min::Int16
-    physical_max::Int16
-    digital_min::Int16
-    digital_max::Int16
+    physical_min::Float32
+    physical_max::Float32
+    digital_min::Float32
+    digital_max::Float32
     prefilter::String
     n_samples::Int16
     samples::Vector{Int16}

--- a/src/read.jl
+++ b/src/read.jl
@@ -59,13 +59,7 @@ function set!(io::IO, sigs::Vector{Signal}, name::Symbol, sz::Integer)
     return set!(io, strip, sigs, name, sz)
 end
 
-# TODO: Emit warning?
-"""
-    parse_int16(raw::String)
-
-Attempt to parse `raw` as an `Int16`, returning 0 if the parsing fails.
-"""
-parse_int16(raw::AbstractString) = something(tryparse(Int16, raw), zero(Int16))
+parse_float(raw::AbstractString) = something(tryparse(Float32, raw), NaN32)
 
 #####
 ##### Reading
@@ -110,12 +104,12 @@ function read_header(io::IO)
     set!(io, signals, :label, 16)
     set!(io, signals, :transducer, 80)
     set!(io, signals, :physical_units, 8)
-    set!(io, parse_int16, signals, :physical_min, 8)
-    set!(io, parse_int16, signals, :physical_max, 8)
-    set!(io, parse_int16, signals, :digital_min, 8)
-    set!(io, parse_int16, signals, :digital_max, 8)
+    set!(io, parse_float, signals, :physical_min, 8)
+    set!(io, parse_float, signals, :physical_max, 8)
+    set!(io, parse_float, signals, :digital_min, 8)
+    set!(io, parse_float, signals, :digital_max, 8)
     set!(io, signals, :prefilter, 80)
-    set!(io, parse_int16, signals, :n_samples, 8)
+    set!(io, x->parse(Int16, x), signals, :n_samples, 8)
 
     skip(io, 32 * n_signals)  # Reserved
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,4 +93,11 @@ const DATADIR = joinpath(@__DIR__, "data")
     @test uneven.header.n_signals == 2
     @test uneven.signals[1].n_samples != uneven.signals[2].n_samples
     @test uneven.annotations === nothing
+
+    nonint = EDF.read(joinpath(DATADIR, "test_float_extrema.edf"))
+    s = first(nonint.signals)
+    @test s.physical_min ≈ -29483.1f0
+    @test s.physical_max ≈ 29483.12f0
+    @test s.digital_min ≈ -32767.0f0
+    @test s.digital_max ≈ 32767.0f0
 end


### PR DESCRIPTION
I had wrongly assumed based on the available examples that these values were integers--that is not the case. This fixes the code such that they are properly parsed and stored as floats and adds a test with a file that stores them as such.