### PR TITLE
Remove `nb_header` from the `EDF.Header` specification

### DIFF
--- a/src/EDF.jl
+++ b/src/EDF.jl
@@ -108,7 +108,6 @@ Type representing the header record for an EDF file.
 * `n_records` (`Int`): Number of data records
 * `duration` (`Float64`): Duration of a data record in seconds
 * `n_signals` (`Int`): Number of signals in a data record
-* `nb_header` (`Int`): Total number of raw bytes in the header record
 """
 struct Header
     version::String
@@ -119,7 +118,6 @@ struct Header
     n_records::Int
     duration::Float64
     n_signals::Int
-    nb_header::Int
 end
 
 # TODO: Make the vector of samples mmappable

--- a/src/read.jl
+++ b/src/read.jl
@@ -125,7 +125,7 @@ function read_header(io::IO)
     @assert position(io) == nb_header
 
     h = Header(version, patient_id, recording_id, continuous, start, n_records,
-               duration, n_signals, nb_header)
+               duration, n_signals)
     return (h, signals, anno_idx)
 end
 

--- a/src/write.jl
+++ b/src/write.jl
@@ -62,15 +62,16 @@ end
 function write_header(io::IO, file::File)
     h = file.header
     has_anno = file.annotations !== nothing
+    signal_count = h.n_signals + has_anno
     b = write_padded(io, h.version, 8) +
         write_padded(io, h.patient, 80) +
         write_padded(io, h.recording, 80) +
         _write(io, Dates.format(h.start, dateformat"dd\.mm\.yyHH\.MM\.SS")) +
-        write_padded(io, h.nb_header, 8) +
+        write_padded(io, 256 * (signal_count + 1), 8) +
         write_padded(io, h.continuous ? "EDF+C" : "EDF+D", 44) +
         write_padded(io, h.n_records, 8) +
         write_padded(io, h.duration, 8) +
-        write_padded(io, h.n_signals + has_anno, 4)
+        write_padded(io, signal_count, 4)
     pads = [16, 80, 8, 8, 8, 8, 8, 80, 8]
     av = Any["EDF Annotations", "", "", -1, 1, -32768, 32767, ""]
     has_anno && push!(av, div(first(file.annotations).n_bytes, 2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,7 +64,8 @@ const DATADIR = joinpath(@__DIR__, "data")
 
     io = IOBuffer()
     nb = EDF.write_header(io, edf)
-    @test nb == edf.header.nb_header
+    has_annotations = edf.annotations !== nothing
+    @test nb == 256 * (edf.header.n_signals + has_annotations + 1)
     EDF.write_data(io, edf)
     seekstart(io)
     h, d, i = EDF.read_header(io)


### PR DESCRIPTION
The value generated by nb_header can be calculated pretty easily during the process of
writing to EDF. Removing this field allows the caller of `EDF.Header` to create an instance
without needing to specify the number of bytes in the header in advance.

The test for `nb_header` has additionally been rewritten to test that the value calculated
in the revised version of `EDF.write` is correct.

This resolves issue https://github.com/beacon-biosignals/EDF.jl/issues/21.