### PR TITLE
[Bugfix] add option to truncate values with size larger than spec

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.4.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
 julia = "1.4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EDF"
 uuid = "ccffbfc1-f56e-50fb-a33b-53d1781b2825"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/EDF.jl
+++ b/src/EDF.jl
@@ -1,6 +1,6 @@
 module EDF
 
-using Dates
+using Dates, Printf
 
 include("types.jl")
 include("read.jl")

--- a/src/write.jl
+++ b/src/write.jl
@@ -15,7 +15,7 @@ function _edf_repr(x::Real)
         end
     else
         fpart, ipart = modf(x)
-        ipart_str = string('-'^signbit(x), Int(abs(ipart)))
+        ipart_str = string('-'^signbit(x), Int(abs(ipart))) # handles `-0.0` case
         fpart_str = @sprintf "%.7f" abs(fpart)
         fpart_str = fpart_str[3:end] # remove leading `0.`
         if length(ipart_str) < 7

--- a/src/write.jl
+++ b/src/write.jl
@@ -7,7 +7,8 @@ _edf_repr(date::Date) = uppercase(Dates.format(date, dateformat"dd-u-yyyy"))
 _edf_repr(date::DateTime) = Dates.format(date, dateformat"dd\.mm\.yyHH\.MM\.SS")
 _edf_repr(x::Integer) = string(x)
 _edf_repr(x::AbstractFloat) = string(isinteger(x) ? trunc(Int, x) : x)
-_edf_repr(::Missing) = 'X'
+_edf_metadata_repr(::Missing) = 'X'
+_edf_metadata_repr(x) = _edf_repr(x)
 
 function _edf_repr(metadata::T) where T<:Union{PatientID,RecordingID}
     header = T <: RecordingID ? String["Startdate"] : String[]

--- a/src/write.jl
+++ b/src/write.jl
@@ -12,7 +12,7 @@ _edf_metadata_repr(x) = _edf_repr(x)
 
 function _edf_repr(metadata::T) where T<:Union{PatientID,RecordingID}
     header = T <: RecordingID ? String["Startdate"] : String[]
-    return join([header; [_edf_repr(getfield(metadata, name)) for name in fieldnames(T)]], ' ')
+    return join([header; [_edf_metadata_repr(getfield(metadata, name)) for name in fieldnames(T)]], ' ')
 end
 
 function edf_write(io::IO, value, byte_limit::Integer; truncate::Bool=true)

--- a/src/write.jl
+++ b/src/write.jl
@@ -17,7 +17,7 @@ end
 
 function edf_write(io::IO, value, byte_limit::Integer; truncate::Bool=true)
     edf_value = _edf_repr(value)
-    @assert isascii(string(edf_value))
+    @assert isascii(edf_value)
     size = length(edf_value)
     if size > byte_limit
         if truncate

--- a/src/write.jl
+++ b/src/write.jl
@@ -22,7 +22,7 @@ function _edf_repr(x::Real)
         fpart_str = @sprintf "%.7f" abs(fpart)
         fpart_str = fpart_str[3:end] # remove leading `0.`
         if length(ipart_str) < 7
-            result = ipart_str * '.' * fpart_str[1:(8 - length(ipart_str))]
+            result = ipart_str * '.' * fpart_str[1:(7 - length(ipart_str))]
         elseif length(ipart_str) <= 8
             result = ipart_str
         end

--- a/src/write.jl
+++ b/src/write.jl
@@ -6,6 +6,9 @@ _edf_repr(value::Union{String,Char}) = value
 _edf_repr(date::Date) = uppercase(Dates.format(date, dateformat"dd-u-yyyy"))
 _edf_repr(date::DateTime) = Dates.format(date, dateformat"dd\.mm\.yyHH\.MM\.SS")
 
+# XXX this is really really hacky and doesn't support use of scientific notation
+# where appropriate; keep in mind if you do improve this to support scientific
+# notation, that scientific is NOT allowed in EDF annotation onset/duration fields
 function _edf_repr(x::Real)
     result = missing
     if isinteger(x)

--- a/src/write.jl
+++ b/src/write.jl
@@ -15,7 +15,7 @@ function _edf_repr(x::Real)
         end
     else
         fpart, ipart = modf(x)
-        ipart_str = string('-'^signbit(x), Int(ipart))
+        ipart_str = string('-'^signbit(x), Int(abs(ipart)))
         fpart_str = @sprintf "%.7f" abs(fpart)
         fpart_str = fpart_str[3:end] # remove leading `0.`
         if length(ipart_str) < 7

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,10 +93,13 @@ const DATADIR = joinpath(@__DIR__, "data")
         @test eof(io)
     end
 
-    buf = IOBuffer()
-    EDF.edf_write(buf, -4.49576549f0, 8)
-    @test String(take!(buf)) == "-4.49576"
-    @test_throws ErrorException EDF.edf_write(buf, -4.49576549f0, 8; truncate=false)
+    @test EDF._edf_repr(34577777) == "34577777"
+    @test EDF._edf_repr(0.0345) == "0.034500"
+    @test EDF._edf_repr(-0.02) == "-0.02000"
+    @test EDF._edf_repr(-187.74445) == "-187.744"
+    @test_throws ErrorException EDF._edf_repr(123456789)
+    @test_throws ErrorException EDF._edf_repr(-12345678)
+    @test_throws ErrorException EDF._edf_repr(0.00000000024)
 
     uneven = EDF.read(joinpath(DATADIR, "test_uneven_samp.edf"))
     @test sprint(show, uneven) == "EDF.File with 2 signals"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,6 +93,11 @@ const DATADIR = joinpath(@__DIR__, "data")
         @test eof(io)
     end
 
+    buf = IOBuffer()
+    EDF.edf_write(buf, -4.49576549f0, 8)
+    @test String(take!(buf)) == "-4.49576"
+    @test_throws ErrorException EDF.edf_write(buf, -4.49576549f0, 8; truncate=false)
+
     uneven = EDF.read(joinpath(DATADIR, "test_uneven_samp.edf"))
     @test sprint(show, uneven) == "EDF.File with 2 signals"
     @test uneven.header.version == "0"


### PR DESCRIPTION
This fixes a bug where certain `Float32` values would have a string representation larger than 8 ASCII characters, since EDF stores by ascii instead of binary representation for numbers. God bless.

This is not a breaking change, but does add optional utility.