### PR TITLE
fix empty TAL handling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EDF"
 uuid = "ccffbfc1-f56e-50fb-a33b-53d1781b2825"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/read.jl
+++ b/src/read.jl
@@ -155,7 +155,8 @@ function read_tal(io::IO)
     timestamp = split(String(bytes), '\x15'; keepempty=false)
     onset_in_seconds = flipsign(parse(Float64, timestamp[1]), sign)
     duration_in_seconds = length(timestamp) == 2 ? parse(Float64, timestamp[2]) : nothing
-    annotations = convert(Vector{String}, split(String(readuntil(io, 0x00)), '\x14'; keepempty=false))
+    annotations = convert(Vector{String}, split(String(readuntil(io, 0x00)), '\x14'; keepempty=true))
+    isempty(last(annotations)) && pop!(annotations)
     return TimestampedAnnotationList(onset_in_seconds, duration_in_seconds, annotations)
 end
 

--- a/src/write.jl
+++ b/src/write.jl
@@ -128,10 +128,15 @@ function write_tal(io::IO, tal::TimestampedAnnotationList)
         bytes_written += Base.write(io, 0x15)
         bytes_written += Base.write(io, _edf_repr(tal.duration_in_seconds))
     end
-    bytes_written += Base.write(io, 0x14)
-    for annotation in tal.annotations
-        bytes_written += Base.write(io, annotation)
+    if isempty(tal.annotations)
         bytes_written += Base.write(io, 0x14)
+        bytes_written += Base.write(io, 0x14)
+    else
+        for annotation in tal.annotations
+            bytes_written += Base.write(io, 0x14)
+            bytes_written += Base.write(io, annotation)
+            bytes_written += Base.write(io, 0x14)
+        end
     end
     bytes_written += Base.write(io, 0x00)
     return bytes_written

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,12 +60,12 @@ const DATADIR = joinpath(@__DIR__, "data")
             # according to the EDF+ specification, onsets should be relative to the start time of
             # the entire file, but it seems like whoever wrote these onsets might have used values
             # that were relative to the start of the surrounding data record
-            expected = [[TimestampedAnnotationList(0.0, nothing, String[]), TimestampedAnnotationList(0.0, nothing, ["start"])],
-                        [TimestampedAnnotationList(1.0, nothing, String[]), TimestampedAnnotationList(0.1344, 0.256, ["type A"])],
-                        [TimestampedAnnotationList(2.0, nothing, String[]), TimestampedAnnotationList(0.3904, 1.0, ["type A"])],
-                        [TimestampedAnnotationList(3.0, nothing, String[]), TimestampedAnnotationList(2.0, nothing, ["type B"])],
-                        [TimestampedAnnotationList(4.0, nothing, String[]), TimestampedAnnotationList(2.5, 2.5, ["type A"])],
-                        [TimestampedAnnotationList(5.0, nothing, String[])]]
+            expected = [[TimestampedAnnotationList(0.0, nothing, String[""]), TimestampedAnnotationList(0.0, nothing, ["start"])],
+                        [TimestampedAnnotationList(1.0, nothing, String[""]), TimestampedAnnotationList(0.1344, 0.256, ["type A"])],
+                        [TimestampedAnnotationList(2.0, nothing, String[""]), TimestampedAnnotationList(0.3904, 1.0, ["type A"])],
+                        [TimestampedAnnotationList(3.0, nothing, String[""]), TimestampedAnnotationList(2.0, nothing, ["type B"])],
+                        [TimestampedAnnotationList(4.0, nothing, String[""]), TimestampedAnnotationList(2.5, 2.5, ["type A"])],
+                        [TimestampedAnnotationList(5.0, nothing, String[""])]]
             @test all(signal.records .== expected)
             @test AnnotationsSignal(signal.records).samples_per_record == 16
         end


### PR DESCRIPTION
So, it turns out empty strings are pretty dang important in EDF land.

Due to the way the EDF spec is worded (and the manner in which external EDF processors are implemented), TALs (even purely timestamped ones) must always contain at least one "annotation", even if it's an empty string. Another way of stating it: a totally empty TAL needs to end with `\x14\x14\x00`. Classic.

This fixes this with a fairly defensive approach: explicitly read in empty strings, and even if the annotations list is totally empty (which would indicated a malformed EDF, in a sense), make sure to write out the `\x14\x14` that the EDF spec hungers for.