### PR TITLE
Support reading truncated files

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -252,11 +252,13 @@ Type representing an EDF file.
 * `io::I`
 * `header::FileHeader`
 * `signals::Vector{Union{Signal,AnnotationsSignal}}`
+* `size::Int`
 """
 struct File{I<:IO}
     io::I
     header::FileHeader
     signals::Vector{Union{Signal,AnnotationsSignal}}
+    size::Int
 end
 
 function Base.show(io::IO, edf::File)

--- a/src/types.jl
+++ b/src/types.jl
@@ -252,13 +252,11 @@ Type representing an EDF file.
 * `io::I`
 * `header::FileHeader`
 * `signals::Vector{Union{Signal,AnnotationsSignal}}`
-* `size::Int`
 """
 struct File{I<:IO}
     io::I
     header::FileHeader
     signals::Vector{Union{Signal,AnnotationsSignal}}
-    size::Int
 end
 
 function Base.show(io::IO, edf::File)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -187,4 +187,8 @@ const DATADIR = joinpath(@__DIR__, "data")
         @test deep_equal(edf.signals[end].records[1:(edf.header.record_count - 1)],
                          truncated_edf.signals[end].records)
     end
+
+    @test EDF._size(edf.io) == 896256
+    @test EDF._size(IOBuffer("memes")) == 5
+    @test EDF._size(Base.DevNull()) == -1
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -188,7 +188,6 @@ const DATADIR = joinpath(@__DIR__, "data")
                          truncated_edf.signals[end].records)
     end
 
-    @test EDF._size(edf.io) == 896256
     @test EDF._size(IOBuffer("memes")) == 5
     @test EDF._size(Base.DevNull()) == -1
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,4 +155,36 @@ const DATADIR = joinpath(@__DIR__, "data")
     for (a, b) in zip(EDF.decode(signal), mne)
         @test a ≈ b atol=0.01
     end
+
+    # Truncated files
+    mktempdir() do dir
+        # note that this tests a truncated final record, not an incorrect number of records
+        full_edf_bytes = read(joinpath(DATADIR, "test.edf"))
+        write(joinpath(dir, "test_truncated.edf"), full_edf_bytes[1:(end - 1)])
+        @test_logs((:warn, "Number of data records in file header does not match " *
+                    "file size. Skipping 1 truncated data record(s)."),
+                   EDF.read(joinpath(dir, "test_truncated.edf")))
+        truncated_edf = EDF.read(joinpath(dir, "test_truncated.edf"))
+        for field in fieldnames(EDF.FileHeader)
+            a = getfield(edf.header, field)
+            b = getfield(truncated_edf.header, field)
+            if field === :record_count
+                @test b == a - 1
+            else
+                @test a == b
+            end
+        end
+        for i in 1:length(edf.signals)
+            good = edf.signals[i]
+            bad = truncated_edf.signals[i]
+            if good isa EDF.Signal
+                @test deep_equal(good.header, bad.header)
+                @test good.samples[1:(end - good.header.samples_per_record)] == bad.samples
+            else
+                @test good.samples_per_record == bad.samples_per_record
+            end
+        end
+        @test deep_equal(edf.signals[end].records[1:(edf.header.record_count - 1)],
+                         truncated_edf.signals[end].records)
+    end
 end


### PR DESCRIPTION
The way I set it up is to track the number of bytes in the EDF file in the `EDF.File` object, then query that relative to the position in the stream when doing reads to determine whether a read would hit EOF. The way the number of bytes is computed up front is mildly janky, as is the check itself. I feel like this approach is probably pretty boneheaded overall; will need to think more about it tomorrow, when hopefully I will have been hit with a jolt of inspiration.

Still needs tests, though luckily this doesn't (yet) break the existing tests.

Fixes #35.