### PR TITLE
Ensure that multiple `EDF.read!`s don't error

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EDF"
 uuid = "ccffbfc1-f56e-50fb-a33b-53d1781b2825"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/read.jl
+++ b/src/read.jl
@@ -227,7 +227,7 @@ Read all EDF sample and annotation data from `file.io` into `file.signals` and
 `file.annotations`, returning `file`. If `eof(file.io)`, return `file` unmodified.
 """
 function read!(file::File)
-    (isopen(file.io) || !eof(file.io)) && read_signals!(file)
+    isopen(file.io) && !eof(file.io) && read_signals!(file)
     return file
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,6 +81,10 @@ const DATADIR = joinpath(@__DIR__, "data")
     EDF.read!(file)
     @test deep_equal(edf.signals, file.signals)
     @test eof(io)
+    # ensure that multiple `EDF.read!` calls don't error and have no effect by
+    # simply rerunning the exact same test as above
+    EDF.read!(file)
+    @test deep_equal(edf.signals, file.signals)
 
     # test that EDF.write(::IO, ::EDF.File) errors if file is
     # discontiguous w/o an AnnotationsSignal present


### PR DESCRIPTION
`EDF.read!(::EDF.File)` is documented to return the file unmodified if `eof(file.io)`, but in practice, calling `read!` again will error since the check for end of file was incorrect. Calling `read!` multiple times will now work as documented.

Fixes https://github.com/beacon-biosignals/OndaEDF.jl/issues/21.