### PR TITLE
Re-release current master as v0.7.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EDF"
 uuid = "ccffbfc1-f56e-50fb-a33b-53d1781b2825"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.6.3"
+version = "0.7.0"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"


### PR DESCRIPTION
The change to make `Signal` parametric in v0.6.3 was inadvertently breaking for some downstream packages.

v0.6.3 is being yanked from the registry in https://github.com/JuliaRegistries/General/pull/46210.