### PR TITLE
Add SSH key to TagBot

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -4,6 +4,8 @@ on:
     types:
       - created
   workflow_dispatch:
+    inputs:
+      lookback:
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'


### PR DESCRIPTION
Closes #52 (well it won't generate those docs, but it'll fix the problem for the future)