### PR TITLE
WIP: Support BDF trigger + status channels

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -171,6 +171,18 @@ function SignalHeader(signal::AnnotationsSignal)
 end
 
 #####
+##### BDF trigger signal
+#####
+
+struct TriggerStatusSignal
+    header::SignalHeader
+    trigger::Vector{UInt16}
+    status::Vector{UInt8}
+end
+
+SignalHeader(signal::TriggerStatusSignal) = signal.header
+
+#####
 ##### EDF+ Patient/Recording Metadata
 #####
 
@@ -264,7 +276,7 @@ Type representing an EDF file with samples encoded as values of type `T`, which 
 struct File{T<:SUPPORTED_SAMPLE_TYPES,I<:IO}
     io::I
     header::FileHeader
-    signals::Vector{Union{Signal{T},AnnotationsSignal}}
+    signals::Vector{Union{Signal{T},AnnotationsSignal,TriggerStatusSignal}}
 end
 
 function Base.show(io::IO, edf::File{T}) where T


### PR DESCRIPTION
See #60 and the [BioSemi format description](https://www.biosemi.com/faq/file_format.htm). Basically the approach here is that we read the "status" signal into its own dedicated type that sits alongside `EDF.Signal` and `EDF.AnnotationsSignal`. When reading the actual values, we take the first two bytes as the trigger and the last as the status. If I'm reading [BioSemi's description](https://www.biosemi.com/faq/trigger_signals.htm) correctly, the individual bits of these signals mean something, so I've opted for now to read them as `UInt16` and `UInt8` rather than some other 2-byte type and `Bool`.

Still to do: More thorough understanding + tests.