### PR TITLE
Fix detection of truncated data records for BDF files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EDF"
 uuid = "ccffbfc1-f56e-50fb-a33b-53d1781b2825"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"

--- a/src/read.jl
+++ b/src/read.jl
@@ -217,7 +217,7 @@ function File(io::IO)
                 return signal.samples_per_record
             end
         end
-        readable_records = div(div(bytes_left, 2), total_expected_samples)
+        readable_records = div(div(bytes_left, sizeof(T)), total_expected_samples)
         if file_header.record_count > readable_records
             @warn("Number of data records in file header does not match file size. " *
                   "Skipping $(file_header.record_count - readable_records) truncated " *

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,15 +162,16 @@ const DATADIR = joinpath(@__DIR__, "data")
     end
 
     # Truncated files
-    mktempdir() do dir
+    dir = mktempdir(; cleanup=true)
+    for full_file in ["test.edf", "evt.bdf"]
         # note that this tests a truncated final record, not an incorrect number of records
-        full_file = joinpath(DATADIR, "test.edf")
-        truncated_file = joinpath(dir, "test_truncated.edf")
-        full_edf_bytes = read(full_file)
+        truncated_file = joinpath(dir, "test_truncated" * last(splitext(full_file)))
+        full_edf_bytes = read(joinpath(DATADIR, full_file))
         write(truncated_file, full_edf_bytes[1:(end - 1)])
         @test_logs((:warn, "Number of data records in file header does not match " *
                     "file size. Skipping 1 truncated data record(s)."),
                    EDF.read(truncated_file))
+        edf = EDF.read(joinpath(DATADIR, full_file))
         truncated_edf = EDF.read(truncated_file)
         for field in fieldnames(EDF.FileHeader)
             a = getfield(edf.header, field)


### PR DESCRIPTION
Checking the number of readable records assumes 16-bit-encoded samples, i.e. an EDF file. However, when reading BDF files, which have 24-bit samples, the computed number of readable records is incorrect and the discrepancy goes unnoticed so we hit an `EOFError`. This can be fixed by checking the size of the sample type rather than assuming it's 2.