### PR TITLE
Write onsets and durations with more decimal digits

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -138,10 +138,10 @@ function write_tal(io::IO, tal::TimestampedAnnotationList)
     if !signbit(tal.onset_in_seconds) # otherwise, the `-` will already be in number string
         bytes_written += Base.write(io, '+')
     end
-    bytes_written += Base.write(io, _edf_repr(tal.onset_in_seconds))
+    bytes_written += Base.write(io, @sprintf("%f", tal.onset_in_seconds))
     if tal.duration_in_seconds !== nothing
         bytes_written += Base.write(io, 0x15)
-        bytes_written += Base.write(io, _edf_repr(tal.duration_in_seconds))
+        bytes_written += Base.write(io, @sprintf("%f", tal.duration_in_seconds))
     end
     if isempty(tal.annotations)
         bytes_written += Base.write(io, 0x14)


### PR DESCRIPTION
> Both Onset and Duration can contain a dot ('.') but only if the fraction of a second is specified (up to arbitrary accuracy).

https://www.edfplus.info/specs/edfplus.html#tal

We are currently subjecting our onsets and durations to the strict 8-char limitation of EDF headers, but that does not seem necessary.

Note this is mostly orthogonal to #70, since that PR does not use scientific notation in TALs anyway (but it does allow underflow-to-zero there, which we can get rid of this way).