### PR TITLE
Declare compatibility with BitIntegers 0.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EDF"
 uuid = "ccffbfc1-f56e-50fb-a33b-53d1781b2825"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.7.4"
+version = "0.7.5"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"
@@ -9,7 +9,7 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-BitIntegers = "0.2"
+BitIntegers = "0.2, 0.3"
 FilePathsBase = "0.9.13"
 julia = "1.4"
 


### PR DESCRIPTION
But continue to allow 0.2 as well. BitIntegers 0.3 made some changes to promotion rules but those don't affect us (as is evidenced by tests passing). They'll only possibly affect downstream users who forget to `decode` the `Int24` signals.