### PR TITLE
Expand byte size of `samples_per_record`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EDF"
 uuid = "ccffbfc1-f56e-50fb-a33b-53d1781b2825"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.7.6"
+version = "0.8.0"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EDF"
 uuid = "ccffbfc1-f56e-50fb-a33b-53d1781b2825"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.7.5"
+version = "0.7.6"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ Where practical, this package chooses field names that are as close to EDF/EDF+ 
 
 ## Breaking Changes
 
-In 0.8 the field `samples_per_record` of `SignalHeader` was changes from `Int16` to `Int32`.
+In v0.8.0, the field `samples_per_record` of `SignalHeader` was changed from `Int16` to `Int32`.

--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ Compared to all features implied by the EDF/EDF+ specifications, this package is
 - Support for [the EDF+ `longinteger`/`float` extension](https://www.edfplus.info/specs/edffloat.html)
 
 Where practical, this package chooses field names that are as close to EDF/EDF+ specification terminology as possible.
+
+## Breaking Changes
+
+In 0.8 the field `samples_per_record` of `SignalHeader` was changes from `Int16` to `Int32`.

--- a/src/read.jl
+++ b/src/read.jl
@@ -115,7 +115,7 @@ function read_signal_headers(io::IO, signal_count)
                                    strip(fields[i, 3]), parse_float(fields[i, 4]),
                                    parse_float(fields[i, 5]), parse_float(fields[i, 6]),
                                    parse_float(fields[i, 7]), strip(fields[i, 8]),
-                                   parse(Int16, fields[i, 9])) for i in 1:size(fields, 1)]
+                                   parse(Int32, fields[i, 9])) for i in 1:size(fields, 1)]
     skip(io, 32 * signal_count) # reserved
     return signal_headers
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -44,7 +44,7 @@ struct SignalHeader
     digital_minimum::Float32
     digital_maximum::Float32
     prefilter::String
-    samples_per_record::Int16
+    samples_per_record::Int32
 end
 
 """
@@ -133,11 +133,11 @@ Type representing a single EDF Annotations signal.
 
 # Fields
 
-* `samples_per_record::Int16`
+* `samples_per_record::Int32`
 * `records::Vector{Vector{TimestampedAnnotationList}}`
 """
 struct AnnotationsSignal
-    samples_per_record::Int16
+    samples_per_record::Int32
     records::Vector{Vector{TimestampedAnnotationList}}
 end
 
@@ -163,11 +163,11 @@ function AnnotationsSignal(records::Vector{Vector{TimestampedAnnotationList}})
     # treated similarly, i.e. the `SignalHeader` is overly trusted).
     max_bytes_per_record = maximum(sum(write_tal(IOBuffer(), tal) for tal in record)
                                    for record in records)
-    return AnnotationsSignal(Int16(cld(max_bytes_per_record, 2)), records)
+    return AnnotationsSignal(Int32(cld(max_bytes_per_record, 2)), records)
 end
 
 function SignalHeader(signal::AnnotationsSignal)
-    return SignalHeader("EDF Annotations", "", "", -1, 1, -32768, 32767,
+    return SignalHeader("EDF Annotations", "", "", -1, 1, typemin(Int16), typemax(Int16),
                         "", signal.samples_per_record)
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -167,7 +167,7 @@ function AnnotationsSignal(records::Vector{Vector{TimestampedAnnotationList}})
 end
 
 function SignalHeader(signal::AnnotationsSignal)
-    return SignalHeader("EDF Annotations", "", "", -1, 1, typemin(Int16), typemax(Int16),
+    return SignalHeader("EDF Annotations", "", "", -1, 1, -32768, 32767, # typemin/typemax
                         "", signal.samples_per_record)
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -167,7 +167,7 @@ function AnnotationsSignal(records::Vector{Vector{TimestampedAnnotationList}})
 end
 
 function SignalHeader(signal::AnnotationsSignal)
-    return SignalHeader("EDF Annotations", "", "", -1, 1, -32768, 32767, # typemin/typemax
+    return SignalHeader("EDF Annotations", "", "", -1, 1, -32768, 32767,
                         "", signal.samples_per_record)
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -33,7 +33,7 @@ Type representing the header for a single EDF signal.
 * `digital_minimum::Float32`: minimum value of the signal that could occur in a data record
 * `digital_maximum::Float32`: maximum value of the signal that could occur in a data record
 * `prefilter::String`: non-standardized prefiltering information
-* `samples_per_record::Int16`: number of samples in a data record (NOT overall)
+* `samples_per_record::Int32`: number of samples in a data record (NOT overall)
 """
 struct SignalHeader
     label::String

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -257,10 +257,10 @@ end
 
 @testset "BDF+ Files" begin
     # This is a `BDF+` file containing only trigger information.
-    # It is similiar to a `EDF Annotations` file except that 
+    # It is similiar to a `EDF Annotations` file except that
     # The `ANNOTATIONS_SIGNAL_LABEL` is `BDF Annotations`.
-    # The test data has 1081 trigger events, and 
-    # has 180 trials in total, and 
+    # The test data has 1081 trigger events, and
+    # has 180 trials in total, and
     # The annotation `255` signifies the offset of a trial.
     # More information, contact: zhanlikan@hotmail.com
     evt = EDF.read(joinpath(DATADIR, "evt.bdf"))


### PR DESCRIPTION
`samples_per_record` is stored as an `Int16` which can cause errors when individual records of an EDF are very large. This expands the size to `Int32`.